### PR TITLE
Fix main POST handler

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -12,7 +12,7 @@ module.exports = function (ref, action) {
 
   // main POST handler
   hookshot.post('/', function (req, res, next) {
-    var payload = JSON.parse(req.body.payload);
+    var payload = req.body;
     if (typeof payload.ref != 'string') {
       throw new Error('Invalid ref');
     }


### PR DESCRIPTION
The `express.bodyParser()` already converts a JSON response to a populated object on `req.body`.

Hookshot crashed always when receiving a payload, because it tried to parse "undefined" with JSON.parse, failing `SyntaxError: Unexpected token u` on line 15.
