### PR TITLE
Acknowledge webhook creation ping

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -18,6 +18,12 @@ module.exports = function (ref, action) {
     if (typeof payload.payload != 'undefined') {
       payload = JSON.parse(payload.payload);
     }
+    // GitHub send an initial ping on webhook creation, detect it by looking for `hook_id`
+    // Send a 200 response and stop further execution of this script.
+    if (typeof payload.hook_id == 'number') {
+      res.send(200, 'OK');
+      return false;
+    }
     if (typeof payload.ref != 'string') {
       throw new Error('Invalid ref');
     }


### PR DESCRIPTION
GitHub sends a ping even on Webhook creation: https://developer.github.com/webhooks/#ping-event

But since it doesn't follow the structure that `lib/index.js` is expecting, that script throws an error, such as when it can't find a string for `payload.ref`.

You could do fancier things to handle this such as emit a `ping` event but this fix will stop the script from breaking for now.
