### PR TITLE
Minor changes to main, added BDD tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,23 @@ hookshot()
 })
 ```
 
+### Spawn Event
+
+If hookshot was created with a shell command as the action, it will throw a spawn event with the child_process spawn instance.
+
+```javascript
+var server = hookshot('refs/head/master', 'git pull && make').listen(3000);
+
+server.on('spawn', function(spawn) {
+  // Bind on close to get exit code
+  spawn.on('close', function(code) {
+    if ( code !== 0 ) {
+      console.log('something went wrong');
+    }
+  });
+});
+```
+
 ### CLI Tool
 
 A companion CLI tool is provided for convenience. To use it, install **hookshot** via npm using the `-g` flag:

--- a/lib/index.js
+++ b/lib/index.js
@@ -30,7 +30,8 @@ module.exports = function (ref, action) {
     }
     hookshot.emit('hook', payload);
     hookshot.emit(payload.ref, payload);
-    res.send(202, 'Accepted\n');
+    res.status(202);
+    res.send('Accepted\n');
   });
 
   if (arguments.length == 1) {
@@ -51,12 +52,27 @@ module.exports = function (ref, action) {
     }
 
     hookshot.on(ref, function(payload) {
-      // shell command
-      spawn(shell, args, opts);
+      // Send emit spawn event w/ instance
+      hookshot.emit('spawn', spawn(shell, args, opts));
     });
   } else if (typeof action == 'function') {
     hookshot.on(ref, action);
   }
+
+  // Development Error middleware
+  if ( process.env.NODE_ENV === 'development' ) {
+    hookshot.use(function(err, req, res, next) {
+      console.log(err.stack);
+      next(err);
+    });
+  }
+
+  // Default Error middlware
+  hookshot.use(function(err, req, res, next) {
+    hookshot.emit('error', err);
+    res.status(500);
+    res.end(err.message);
+  });
 
   return hookshot;
 };

--- a/package.json
+++ b/package.json
@@ -2,8 +2,15 @@
   "name": "hookshot",
   "author": "Marco Aurelio <thecoreh@gmail.com>",
   "version": "0.1.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/coreh/hookshot.git"
+  },
+  "scripts": {
+    "test": "node_modules/.bin/mocha"
+  },
   "dependencies": {
-    "express": "~4.9.0", 
+    "express": "~4.9.0",
     "commander": "~2.3.0",
     "lockfile": "~1.0.0",
     "body-parser": "~1.8.2"
@@ -11,5 +18,9 @@
   "main": "lib",
   "bin": {
     "hookshot": "./bin/hookshot"
+  },
+  "devDependencies": {
+    "mocha": "^2.2.5",
+    "supertest": "^1.0.1"
   }
 }

--- a/test/test.js
+++ b/test/test.js
@@ -1,0 +1,130 @@
+var assert    = require('assert'),
+    supertest = require('supertest'),
+    hookshot  = require('../lib');
+
+process.env.NODE_ENV = 'test';
+
+describe('hookshot server', function() {
+
+  var server, request;
+
+  beforeEach(function() {
+     server = hookshot('test', 'exit 1'),
+     request = supertest(server);
+  });
+
+  it('should throw an error on invalid payload', function(done) {
+    request
+      .post('/')
+      .set('Accept', 'application/json')
+      .send({})
+      .end(function(err) {
+        assert(err);
+        done();
+      });
+  });
+
+  it('should emit an error on invalid payload', function(done) {
+
+    var errorEmitCheck = function(err) {
+      assert(err);
+      done();
+      server.removeListener('error', errorEmitCheck);
+    };
+
+    server.on('error', errorEmitCheck);
+
+    request
+      .post('/')
+      .set('Accept', 'application/json')
+      .send({})
+      .expect(500)
+      .end(function(err) {
+        assert(err);
+      });
+  });
+
+  it('should get a create event', function(done) {
+    server.on('create', function(payload) {
+      assert(payload);
+      done();
+    });
+
+    request
+      .post('/')
+      .set('Accept', 'application/json')
+      .send({ ref: 'test', created: true })
+      .expect(202)
+      .end(function(err, res) {
+        assert(!err);
+      });
+  });
+
+  it('should get a delete event', function(done) {
+    server.on('delete', function(payload) {
+      assert(payload);
+      done();
+    });
+
+    request
+      .post('/')
+      .set('Accept', 'application/json')
+      .send({ ref: 'test', deleted: true })
+      .expect(202)
+      .end(function(err, res) {
+        assert(!err);
+      });
+  });
+
+  it('should get a push event if created and deleted are falsy', function(done) {
+    server.on('push', function(payload) {
+      assert(payload);
+      done();
+    });
+
+    request
+      .post('/')
+      .set('Accept', 'application/json')
+      .send({ ref: 'test' })
+      .expect(202)
+      .end(function(err, res) {
+        assert(!err);
+      });
+  });
+
+  it('should get reference event with payload on hook', function(done) {
+    server.on('test', function(payload) {
+      done();
+    });
+
+    request
+      .post('/')
+      .set('Accept', 'application/json')
+      .send({ ref: 'test' })
+      .expect(202)
+      .end(function(err, res) {
+        assert(!err);
+      });
+
+  });
+
+  it('should run command `exit 1` when running receiving a hook for reference "test"', function(done) {
+
+    server.on('spawn', function(instance) {
+      instance.on('close', function(code) {
+        assert.equal(code, 1);
+        done();
+      });
+    });
+
+    request
+      .post('/')
+      .set('Accept', 'application/json')
+      .send({ ref: 'test' })
+      .expect(202)
+      .end(function(err, res) {
+        assert(!err);
+      });
+  });
+});
+

--- a/test/test.js
+++ b/test/test.js
@@ -19,20 +19,17 @@ describe('hookshot server', function() {
       .set('Accept', 'application/json')
       .send({})
       .end(function(err) {
-        assert(err);
+        assert(err instanceof Error);
         done();
       });
   });
 
   it('should emit an error on invalid payload', function(done) {
 
-    var errorEmitCheck = function(err) {
-      assert(err);
+    server.on('error', function(err) {
+      assert(err instanceof Error);
       done();
-      server.removeListener('error', errorEmitCheck);
-    };
-
-    server.on('error', errorEmitCheck);
+    });
 
     request
       .post('/')
@@ -40,7 +37,7 @@ describe('hookshot server', function() {
       .send({})
       .expect(500)
       .end(function(err) {
-        assert(err);
+        assert(err instanceof Error);
       });
   });
 


### PR DESCRIPTION
Thanks for this cool package!

In effort to try continue development on this module, I added basic BDD tests. To properly handle errors in the tests, I had to add basic error handling middleware to the `lib/index.js`.

To run tests:

```
npm install
npm test
```

Additionally, added a spawn event which passes the child_process instance. This could be useful to hooking into and logging command output or getting the exit code.

Also, I can add a `.travis.yml` if you would like. 
