### PR TITLE
Pass through bodyParser.json() middleware options

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -3,14 +3,14 @@ var normalize = require('path').normalize;
 var spawn = require('child_process').spawn;
 var express = require('express');
 
-module.exports = function (ref, action) {
+module.exports = function (ref, action, body_parser_json_options) {
 
   // create express instance
   var hookshot = express();
 
   // middleware
   hookshot.use(bodyParser.urlencoded({ extended: false }));
-  hookshot.use(bodyParser.json());
+  hookshot.use(bodyParser.json(body_parser_json_options));
 
   // main POST handler
   hookshot.post('/', function (req, res, next) {


### PR DESCRIPTION
[18F/pages](https://github.com/18F/pages) is a Hookshot server for https://pages.18f.gov/. As noted in 18F/pages#14, the default 100KB payload limit was exceeded by a webhook fired for 18F/govt-wide-patternlibrary#54. This change will allow us to pass options through to the `bodyParser.json()` middleware to increase the limit.

I've currently installed this on our server using:

``` shell
$ npm install git+ssh://git@github.com/18F/hookshot.git#json-options
```

I've also updated our 18F/pages server to use this version, and verified that it addresses our problem, evidenced by the logs and the successful first deployment of https://pages.18f.gov/govt-wide-patternlibrary/.

cc: @juliaelman
