### PR TITLE
Fix deprecated use of res.send

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -30,7 +30,7 @@ module.exports = function (ref, action) {
     }
     hookshot.emit('hook', payload);
     hookshot.emit(payload.ref, payload);
-    res.send(202, 'Accepted\n');
+    res.sendStatus(202);
   });
 
   if (arguments.length == 1) {


### PR DESCRIPTION
Small patch to resolve warning message I've been getting: 

`express deprecated res.send(status, body): Use res.status(status).send(body) instead at home/ubuntu/node_modules/hookshot/lib/index.js:33:9`
